### PR TITLE
Fix sync to exclude user-scoped taskmaster directories

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,7 +174,7 @@ The repository includes a GitHub workflow that customizes the template:
 - Use Actions → Template Sync to pull upstream configuration updates
 - Always review PR changes before merging to preserve local customizations
 - Sync preserves project-specific values (name, language, prompts) via manifest variables
-- User-scoped files like `.taskmaster/tasks/` and `.taskmaster/docs/` are never modified
+- User-scoped files like `.taskmaster/tasks/`, `.taskmaster/docs/`, and `.taskmaster/reports/` are never modified
 - Sync infrastructure (workflow and script) are also updated when upstream has changes
 
 ## Testing

--- a/docs/template-sync/design.md
+++ b/docs/template-sync/design.md
@@ -224,6 +224,7 @@ Files that are user-specific or gitignored:
 - `.claude/settings.local.json` (if it existed, would be gitignored)
 - `.taskmaster/tasks/**` (project-specific task data)
 - `.taskmaster/docs/**` (project-specific PRDs)
+- `.taskmaster/reports/**` (project-specific analysis reports)
 - `.env` files
 - Any gitignored files
 

--- a/docs/template-sync/implementation.md
+++ b/docs/template-sync/implementation.md
@@ -297,7 +297,7 @@ This is a copy of the workflow created in Task 4, placed in the templates direct
 
 #### Unit Test Suite
 
-Located in `test/` directory with 68 total tests across 3 test files:
+Located in `test/` directory with 79 total tests across 3 test files:
 
 **Test Directory Structure**:
 ```
@@ -327,7 +327,7 @@ for test in test/test-*.sh; do $test; done
 | Suite | Tests | Coverage |
 |-------|-------|----------|
 | test-manifest-jq.sh | 17 | jq patterns, JSON generation, special characters, round-trip |
-| test-template-sync.sh | 33 | CLI parsing, manifest reading/validation, sed escaping, substitutions, file comparison, diff reports |
+| test-template-sync.sh | 44 | CLI parsing, manifest reading/validation, sed escaping, substitutions, file comparison, diff reports, user-scoped directory exclusions |
 | test-template-cleanup.sh | 18 | Manifest generation, fields, variables, special chars, git tag/SHA detection, schema validation |
 
 **Functions Tested in template-sync.sh**:


### PR DESCRIPTION
We shouldn't try to sync taskmaster tasks, docs and reports