### PR TITLE
Fix the sync action summary

### DIFF
--- a/.github/workflows/template-sync.yml
+++ b/.github/workflows/template-sync.yml
@@ -246,6 +246,8 @@ jobs:
 
       - name: Summary
         if: always()
+        env:
+          DIFF_SUMMARY: ${{ needs.sync.outputs.diff_summary }}
         run: |
           echo "### Template Sync Results" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
@@ -260,4 +262,5 @@ jobs:
           echo "**Version:** ${{ needs.sync.outputs.old_version }} → ${{ needs.sync.outputs.new_version }}" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "#### Changes" >> "$GITHUB_STEP_SUMMARY"
-          echo "${{ needs.sync.outputs.diff_summary }}" >> "$GITHUB_STEP_SUMMARY"
+          # Use printf to avoid bash interpreting backticks in markdown as command substitution
+          printf '%s\n' "$DIFF_SUMMARY" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
1. Store the output in an environment variable (DIFF_SUMMARY) - GitHub Actions handles this safely without bash interpretation
2. Use printf '%s\n'  instead of echo "${{ ... }}" - printf '%s' prints the string literally without interpreting any special characters