### PR TITLE
Fix docs/update.sh not preserved during template cleanup

### DIFF
--- a/.github/scripts/template-cleanup.sh
+++ b/.github/scripts/template-cleanup.sh
@@ -429,6 +429,13 @@ execute_cleanup() {
   rm -f .github/scripts/template-cleanup.sh
   rm -f .github/workflows/template-cleanup.yml
 
+  log_step "Preserving docs/update.sh..."
+  local tmpfile=""
+  if [[ -f docs/update.sh ]]; then
+    tmpfile="$(mktemp)"
+    cp docs/update.sh "$tmpfile"
+  fi
+
   log_step "Cleaning up template-specific files..."
   find . -mindepth 1 -maxdepth 1 \
     ! -name '.git' \
@@ -438,6 +445,13 @@ execute_cleanup() {
     ! -name '.serena' \
     ! -name 'bootstrap.sh' \
     -exec rm -rf {} +
+
+  if [[ -n "$tmpfile" ]]; then
+    mkdir -p docs
+    cp "$tmpfile" docs/update.sh
+    chmod +x docs/update.sh
+    rm -f "$tmpfile"
+  fi
 
   log_step "Generating template state manifest..."
   generate_manifest "$name"

--- a/docs/template-sync/template-state-schema.json
+++ b/docs/template-sync/template-state-schema.json
@@ -67,7 +67,7 @@
           "description": "Initial prompt/context for Serena MCP server. Substituted into .serena/project.yml (initial_prompt field). Only applied if non-empty.",
           "default": "",
           "examples": ["", "You are working on a TypeScript project"]
-        },
+        }
       }
     },
     "sync_exclusions": {


### PR DESCRIPTION
Preserve docs/update.sh through a temp file copy before the cleanup
find command wipes the docs/ directory, then restore it after.
Also fix trailing comma in template-state-schema.json that broke
JSON schema validation.

## Test Plan
run test scripts