### PR TITLE
Front-load skill descriptions to avoid 250-char truncation

### DIFF
--- a/klaude-plugin/.claude-plugin/plugin.json
+++ b/klaude-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "kk",
   "description": "Development workflow skills, commands, and hooks from claude-toolbox",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "author": {
     "name": "serpro69"
   },

--- a/klaude-plugin/skills/analysis-process/SKILL.md
+++ b/klaude-plugin/skills/analysis-process/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: analysis-process
-description: Turn the idea for a feature into a fully-formed PRD/design/specification and implementation-plan. Use when you have a spec or requirements that needs implementation. Use in pre-implementation (idea-to-design) stages to make sure you understand the spec/requirements and ensure you have a correct implementation plan before writing actual code.
+description: |
+  Use in pre-implementation (idea-to-design) stages to understand spec/requirements and create a correct implementation plan before writing actual code.
+  Turns ideas into a fully-formed PRD/design/specification and implementation-plan. Creates design docs and task lists in docs/wip/.
 ---
 
 # Task Analysis Process

--- a/klaude-plugin/skills/cove/SKILL.md
+++ b/klaude-plugin/skills/cove/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: cove
-description: Apply Chain-of-Verification (CoVe) prompting to improve response accuracy through self-verification. Use when complex questions require fact-checking, technical accuracy, or multi-step reasoning.
+description: |
+  Apply Chain-of-Verification (CoVe) prompting to improve response accuracy through self-verification.
+  Use when complex questions require fact-checking, technical accuracy, or multi-step reasoning.
 ---
 
 # Chain-of-Verification (CoVe)

--- a/klaude-plugin/skills/development-guidelines/SKILL.md
+++ b/klaude-plugin/skills/development-guidelines/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: development-guidelines
-description: Use when writing code to ensure you follow development best practices during development and implementation.
+description: |
+  Use when writing code to ensure you follow development best practices during development and implementation.
 ---
 
 # Development Guidelines

--- a/klaude-plugin/skills/documentation-process/SKILL.md
+++ b/klaude-plugin/skills/documentation-process/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: documentation-process
-description: After implementing a new feature or fixing a bug, make sure to document the changes. Use when writing documentation, after finishing the implementation phase for a feature or a bug-fix
+description: |
+  After implementing a new feature or fixing a bug, make sure to document the changes.
+  Use when writing documentation, after finishing the implementation phase for a feature or a bug-fix.
 ---
 
 # Documentation Process

--- a/klaude-plugin/skills/implementation-process/SKILL.md
+++ b/klaude-plugin/skills/implementation-process/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: implementation-process
-description: Implement a feature using the written implementation plan. Use when you have a fully-formed written implementation plan to execute in a separate session with review checkpoints. TRIGGER when: the user asks to work on, implement, or continue a task from a docs/wip feature (e.g., "work on task 1", "let's do the next task", "implement the first task for X feature", "continue with the auth system tasks").
+description: |
+  TRIGGER when: user asks to work on, implement, or continue tasks from docs/wip (e.g. "work on task 1", "do the next task", "implement first task for X").
+  Executes written implementation plans with review checkpoints. Use when you have a fully-formed implementation plan to execute in a separate session.
 ---
 
 # Executing Plans

--- a/klaude-plugin/skills/implementation-review/SKILL.md
+++ b/klaude-plugin/skills/implementation-review/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: implementation-review
-description: Verify implemented code matches design and implementation documentation. Detects spec deviations, missing implementations, doc inconsistencies, and outdated docs. Use after implementing tasks or mid-way through a feature to ensure code and docs are in sync.
+description: |
+  Use after implementing tasks or mid-feature to verify code matches design docs and ensure they are in sync.
+  Detects spec deviations, missing implementations, doc inconsistencies, and outdated docs in design and implementation documentation.
 ---
 
 # Implementation Review

--- a/klaude-plugin/skills/merge-docs/SKILL.md
+++ b/klaude-plugin/skills/merge-docs/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: merge-docs
-description: Semantically compare and merge two design docs for the same feature into one unified document. Use when you have two competing or complementary design/implementation docs (e.g., from separate analysis-process runs) and need to reconcile them into a single source of truth.
+description: |
+  Compare and merge two design docs for the same feature into a single source of truth.
+  Use when you have competing or complementary design/implementation docs (e.g. from separate analysis-process runs) that need reconciling into one unified document.
 ---
 
 # Merge Design Documents

--- a/klaude-plugin/skills/solid-code-review/SKILL.md
+++ b/klaude-plugin/skills/solid-code-review/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: solid-code-review
-description: "Code review of current git changes with an expert senior-engineer lens. Detects SOLID violations, security risks, and proposes actionable improvements. Use when performing code reviews."
+description: |
+  Code review of current git changes with an expert senior-engineer lens. Detects SOLID violations, security risks, and proposes actionable improvements.
+  Use when performing code reviews.
 ---
 
 # SOLID Code Review

--- a/klaude-plugin/skills/testing-process/SKILL.md
+++ b/klaude-plugin/skills/testing-process/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: testing-process
-description: Guidelines describing how to test the code. Use whenever writing new or updating existing code, for example after implementing a new feature or fixing a bug.
+description: |
+  Guidelines describing how to test the code.
+  Use whenever writing new or updating existing code, for example after implementing a new feature or fixing a bug.
 ---
 
 # Testing & Quality Assurance Process


### PR DESCRIPTION
Skill descriptions in the system reminder listing are capped at 250 characters. Several skills had their key use-case and TRIGGER clauses truncated because they appeared after verbose preamble. Reorder all descriptions so the most important info (trigger conditions, primary use case) comes first. Also use YAML block scalars for readability.

Bump plugin version to 0.5.1.