### PR TITLE
Scope isolated reviews to in-progress tasks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,23 @@ Symmetric naming avoids stuttering (`/kk:cove:cove` → `/kk:chain-of-verificati
 
 Agent names describe the **role**, not the skill that invokes them. `code-reviewer`, `design-reviewer`, `spec-reviewer` persist across skill renames. Don't rename agent files when renaming the skills that delegate to them.
 
+### Shared instructions
+
+Instructions referenced by more than one skill live in `klaude-plugin/skills/_shared/<name>.md` with a bare basename (e.g., `review-scope-protocol.md`, `pal-codereview-invocation.md`).
+
+Each consuming skill gets a **per-skill symlink** at `klaude-plugin/skills/<skill>/shared-<name>.md` pointing to `../_shared/<name>.md`. Reasons:
+
+- Markdown links inside a skill stay local — `[shared-foo.md](shared-foo.md)` resolves without `../` path traversal, which keeps links working when the skill is bundled/copied.
+- The `shared-` prefix in the skill directory makes it obvious at a glance which files are shared vs skill-specific.
+- Only symlink into skills that actually reference the file — don't blanket-symlink.
+
+When adding a new shared instruction:
+
+1. Create `klaude-plugin/skills/_shared/<name>.md` (bare basename, no `shared-` prefix on the source file).
+2. In each consuming skill directory, run `ln -s ../_shared/<name>.md shared-<name>.md`.
+3. Reference it in skill docs as `[shared-<name>.md](shared-<name>.md)`.
+4. Agents (in `klaude-plugin/agents/`) can't use the per-skill symlink pattern — reference shared files by their repo-relative path: `klaude-plugin/skills/_shared/<name>.md`.
+
 ### When renaming
 
 - Update `test/test-plugin-structure.sh` `EXPECTED_SKILLS` and `EXPECTED_COMMANDS`.

--- a/klaude-plugin/agents/code-reviewer.md
+++ b/klaude-plugin/agents/code-reviewer.md
@@ -21,6 +21,7 @@ The spawning workflow injects these artifacts into your prompt:
 
 - **Git diff** of the changes under review
 - **Spec context** (if available): relevant section from design.md, task description, documented design rationale
+- **Task scope** (if available): which tasks in the feature are in scope for this review and which are pending/out-of-scope — see `klaude-plugin/skills/_shared/review-scope-protocol.md`. When present, this overrides naive reading of the design doc: the design describes the full end state, but only in-scope tasks are expected in the diff.
 - **Primary language** detected from the diff, with path to language-specific checklists
 - **Capy read access** for project-specific context via `capy_search`
 
@@ -166,3 +167,4 @@ Structure your output exactly as follows. This is the contract the annotation ph
 - Do NOT add findings outside the P0-P3 structure.
 - Do NOT include a "next steps" or "how to proceed" section — the reconciliation phase handles that.
 - If no issues found, state what was checked and any residual risks under "Areas Not Covered".
+- **Respect task scope.** If a Task Scope block is present in your prompt, do NOT flag missing functionality that is covered only by out-of-scope (pending/in-progress) tasks. The design doc describes the full end state; pending tasks are expected gaps. Flag only issues within the in-scope changes. If a concern only becomes valid once pending work lands, mention it under "Areas Not Covered" instead of the P0–P3 sections.

--- a/klaude-plugin/agents/spec-reviewer.md
+++ b/klaude-plugin/agents/spec-reviewer.md
@@ -20,8 +20,8 @@ Your isolation is structural: you have full access to the spec documents and sou
 The spawning workflow injects these into your prompt:
 
 - **Design docs**: paths to `design.md` and `implementation.md` for the feature
-- **Task tracking**: path to `tasks.md` with current task statuses (determines review scope)
-- **Review scope**: which tasks to review (completed tasks only, or all)
+- **Task tracking**: path to `tasks.md` with current task statuses
+- **Task scope**: which tasks are in scope (done) and which are out-of-scope (pending/in-progress) — see `klaude-plugin/skills/_shared/review-scope-protocol.md` for the artifact shape and interpretation rules
 - **Read/Grep/Glob access** to source files in the repository
 - **Capy read access** for project-specific context via `capy_search`
 

--- a/klaude-plugin/skills/_shared/review-scope-protocol.md
+++ b/klaude-plugin/skills/_shared/review-scope-protocol.md
@@ -1,0 +1,54 @@
+## Review scope protocol
+
+Isolated reviewers see the diff and the design docs but have zero visibility into which tasks are done versus pending. Without scope, they flag code-that-isn't-written-yet as `MISSING_IMPL` (spec review) or as missing functionality (code review). This protocol defines a scope artifact both skills inject into their sub-agent and external-reviewer prompts.
+
+### Input shapes
+
+The review workflow must handle three invocation shapes:
+
+1. **Invoked from `implement`** — `/docs/wip/[feature]/` exists with `design.md`, `implementation.md`, `tasks.md`. The current task id is known (the one just finished). Use full scope filtering.
+2. **Invoked directly inside a feature** — `/docs/wip/[feature]/` exists but no current task is explicitly supplied. Derive scope from `tasks.md` status fields (`done` = in scope, `pending`/`in-progress` = out of scope).
+3. **Invoked on an arbitrary diff** — no `/docs/wip/` directory relates to the diff. Skip the scope artifact entirely and note "No task scope available" in the reviewer prompt.
+
+### Scope artifact format
+
+When shape 1 or 2 applies, build this block and inject it into every reviewer prompt (sub-agent prompt template and the external-reviewer `step` framing):
+
+```
+## Task Scope
+
+Review mode: {mid-implementation | post-implementation}
+
+In scope (review these):
+- Task {id}: {title} — status: done
+- [...more done tasks if applicable]
+
+Out of scope (pending — DO NOT flag as missing):
+- Task {id}: {title} — status: {pending|in-progress}
+- [...more pending tasks]
+
+The feature's design docs describe the full end state. Pending tasks are expected gaps in the current diff — treat their absence from the code as intentional, not as a finding. You may still flag issues within the in-scope tasks even if they reference pending tasks (e.g., a broken interface contract).
+```
+
+When shape 3 applies, use:
+
+```
+## Task Scope
+
+No task scope available — review the diff on its own merits without assuming any feature-level design doc.
+```
+
+### Determining mode
+
+- **mid-implementation** — at least one task in `tasks.md` has status `pending` or `in-progress`.
+- **post-implementation** — all tasks are `done`.
+
+In shape 1, the invoking workflow (`implement`) may pass the current task id directly; that task is automatically in scope even if `tasks.md` hasn't been updated yet.
+
+### Interpretation guidance for reviewers
+
+The reviewer prompt must also carry this instruction (agent definitions should state it; the workflow relays it implicitly via the scope block):
+
+- Do **not** report missing-implementation findings for items covered only by out-of-scope tasks.
+- Do still report real issues *within* the in-scope tasks, including ones that affect future pending work (e.g., a public API the pending task will depend on is shaped wrongly).
+- If a finding would be valid *only* after pending work lands, mention it under "Areas Not Covered" instead of the P0–P3 sections.

--- a/klaude-plugin/skills/review-code/review-isolated.md
+++ b/klaude-plugin/skills/review-code/review-isolated.md
@@ -14,7 +14,7 @@ Isolated Code Review Progress:
 
 ## Contents
 
-- **Step 1: Prepare Artifacts** — 1a) Capture diff, 1b) Locate spec context, 1c) Detect language, 1d) Resolve pal model, 1e) Curate rejected approaches
+- **Step 1: Prepare Artifacts** — 1a) Capture diff, 1b) Locate spec context, 1c) Detect language, 1d) Resolve pal model, 1e) Curate rejected approaches, 1f) Determine task scope
 - **Step 2: Spawn Reviewers** — Reviewer A (code-reviewer sub-agent), Reviewer B (pal codereview), error handling
 - **Step 3: Annotate Findings** — 3a) Duplicate merging, 3b) Author context, 3c) Author-sourced findings, 3d) pal follow-up
 - **Step 4: Index Findings**
@@ -65,6 +65,16 @@ Call `pal` `listmodels` to get available models. Select the most capable model (
 
 Before spawning sub-agents, prepare a brief summary of approaches that were tried and failed during implementation. Keep it to concrete facts ("approach X caused regression Y"), not the full debugging narrative. If no approaches were rejected, skip this.
 
+### 1f) Determine task scope
+
+Build the Task Scope artifact following [shared-review-scope-protocol.md](shared-review-scope-protocol.md). This is what prevents reviewers from flagging pending tasks as missing functionality — it is not optional when a feature directory is present.
+
+- **Invoked from `implement`**: the feature directory and current task are known. Read `tasks.md`, list the current task (plus any other `done` tasks) as in-scope and any `pending`/`in-progress` tasks as out-of-scope. Use mode `mid-implementation` unless all tasks are `done`.
+- **Invoked directly inside a feature**: locate the relevant `/docs/wip/[feature]/tasks.md`. Classify by status field. Use `post-implementation` only when every task is `done`.
+- **No feature directory relates to the diff**: emit the "No task scope available" variant from the shared protocol and proceed.
+
+The resulting block is inlined into both reviewer prompts in Step 2.
+
 ---
 
 ## Step 2: Spawn Reviewers (Parallel)
@@ -99,6 +109,8 @@ klaude-plugin/skills/review-code/reference/{language_key}/
 
 {spec excerpt from Step 1b, or "No spec context available — review based on code quality alone."}
 
+{Task Scope block from Step 1f — either the populated scope artifact or the "No task scope available" variant}
+
 ## Rejected Approaches
 
 {curated rejected approaches from Step 1e, or "No rejected approaches to note."}
@@ -110,7 +122,7 @@ Produce your findings in the output format specified in your agent definition.
 
 Follow the invocation protocol in [shared-pal-codereview-invocation.md](shared-pal-codereview-invocation.md).
 
-For the `step` parameter in step 1, use the git diff prepared in Step 1c. For the `model` parameter, use the model resolved in Step 1d.
+For the `step` parameter in step 1, prepend the Task Scope block from Step 1f (so pal shares the same scope as the sub-agent) and then include the git diff. For the `model` parameter, use the model resolved in Step 1d.
 
 ### Parallel execution
 

--- a/klaude-plugin/skills/review-code/shared-review-scope-protocol.md
+++ b/klaude-plugin/skills/review-code/shared-review-scope-protocol.md
@@ -1,0 +1,1 @@
+../_shared/review-scope-protocol.md

--- a/klaude-plugin/skills/review-spec/review-isolated.md
+++ b/klaude-plugin/skills/review-spec/review-isolated.md
@@ -40,13 +40,12 @@ If any are missing, inform the user and stop.
 
 ### 1c) Determine review scope
 
-Read `tasks.md` to classify each task:
-- **Done**: task is completed and should be reviewed
-- **Pending/In-progress**: task is not yet complete and should be skipped
+Build the Task Scope artifact following [shared-review-scope-protocol.md](../_shared/review-scope-protocol.md). Read `tasks.md`, classify each task by its status field, and derive the review mode:
 
-Determine the review mode:
-- **Mid-implementation**: some tasks are pending — review only completed tasks
-- **Post-implementation**: all tasks are done — review everything
+- **Mid-implementation**: some tasks are `pending`/`in-progress` — review only completed tasks
+- **Post-implementation**: all tasks are `done` — review everything
+
+The resulting scope block is inlined into the sub-agent prompt in Step 2.
 
 ### 1d) Prepare sub-agent context
 

--- a/klaude-plugin/skills/review-spec/review-isolated.md
+++ b/klaude-plugin/skills/review-spec/review-isolated.md
@@ -40,7 +40,7 @@ If any are missing, inform the user and stop.
 
 ### 1c) Determine review scope
 
-Build the Task Scope artifact following [shared-review-scope-protocol.md](../_shared/review-scope-protocol.md). Read `tasks.md`, classify each task by its status field, and derive the review mode:
+Build the Task Scope artifact following [shared-review-scope-protocol.md](shared-review-scope-protocol.md). Read `tasks.md`, classify each task by its status field, and derive the review mode:
 
 - **Mid-implementation**: some tasks are `pending`/`in-progress` — review only completed tasks
 - **Post-implementation**: all tasks are `done` — review everything

--- a/klaude-plugin/skills/review-spec/shared-review-scope-protocol.md
+++ b/klaude-plugin/skills/review-spec/shared-review-scope-protocol.md
@@ -1,0 +1,1 @@
+../_shared/review-scope-protocol.md


### PR DESCRIPTION
Isolated reviewers saw the full feature design but had no signal for
which tasks were done vs pending, so they flagged pending work as
missing functionality. Introduces a shared Task Scope protocol that
both review-code:isolated and review-spec:isolated inject into their
sub-agent and pal codereview prompts.

  - New shared/review-scope-protocol.md defines the scope artifact,
    three invocation shapes (implement / feature-dir / arbitrary diff),
    and interpretation rules
  - review-code:isolated gains Step 1f; scope is threaded into the
    sub-agent template and pal step framing
  - code-reviewer agent adds a "Respect task scope" output rule
  - review-spec:isolated and spec-reviewer refactored to reference the
    shared protocol (behavior unchanged)

## Test Plan
n/a