### PR TITLE
Add standalone mode to 'implement' skill for bug fixes and one-off tasks

### DIFF
--- a/klaude-plugin/skills/implement/SKILL.md
+++ b/klaude-plugin/skills/implement/SKILL.md
@@ -47,7 +47,7 @@ When set, all review checkpoints automatically use isolated variants (`kk:review
 
 ## Workflow
 
-**Mandatory order — understand before executing.** The flow below is strictly sequential. Do not read source files to modify, write code, edit files, run tests, or otherwise act on any task until you have loaded full context (plan documents or problem understanding) and completed profile detection and loaded all resolved profile content. The only early contact with the codebase is the task's target filenames — enough to drive profile detection, not enough to pattern-match implementation. See [ADR 0004](../../../docs/adr/0004-skill-workflow-ordering.md) for the rationale.
+**Mandatory order — understand before executing.** The flow below is strictly sequential. Do not read source files to modify, write code, edit files, run tests, or otherwise act on any task until you have loaded full context (design, implementation plan, task list in **plan mode**, or full problem understanding in **standalone**) and completed profile detection and loaded all resolved profile content. The only early contact with the codebase is the task's target filenames — enough to drive profile detection, not enough to pattern-match implementation. See [ADR 0004](../../../docs/adr/0004-skill-workflow-ordering.md) for the rationale.
 
 ## The Process
 
@@ -69,7 +69,7 @@ After completing the mode's entry procedure, continue with Step 2.
 3. **Dependency-handling (pre-write).** Whenever the task introduces or changes a dependency — new import, version bump, unfamiliar call, **and per the widened trigger also: a Kubernetes API version, a CRD, a Helm chart or chart dependency, or a container image tag/digest** — apply the `dependency-handling` skill BEFORE writing the call. Do not guess signatures, API versions, or configuration; look them up via capy/context7 per that skill's rules. Per-profile lookup cascades live in each profile's `overview.md` (e.g., `${CLAUDE_PLUGIN_ROOT}/profiles/k8s/overview.md` §Looking up Kubernetes dependencies).
 4. Make the changes. (Plan mode: follow the plan exactly.)
 5. (Plan mode only) Check off subtasks (`- [x]`) in `tasks.md` as you complete them.
-6. Run verifications; use `test` skill.
+6. Run verifications; run `kk:test` skill.
 
 ### Step 3: Report and Review
 
@@ -82,7 +82,15 @@ After completing the mode's entry procedure, continue with Step 2.
 - Based on user and code-review feedback: apply changes if needed and finalize
 - (Plan mode only) Update `tasks.md`: set the task's status to `done`
 
-**After finalizing**, verify all items in the **Required Outputs** section above. If any item is unchecked, go back and complete it.
+**After finalizing**, verify all items in the **Required Outputs** section above:
+
+- [ ] Implementation addresses the requirement (plan mode: implementation matches plan)
+- [ ] Verification/tests pass, `kk:test` completed
+- [ ] Code review completed (via `review-code` — which owns indexing its own `kk:review-findings`)
+- [ ] New project conventions indexed as `kk:project-conventions` (skip if none established)
+- [ ] (Plan mode only) `tasks.md` updated to `done`
+
+If any item is unchecked, go back and complete it. Do NOT proceed to the next task with incomplete outputs.
 
 ### Step 4: Continue (plan mode only)
 
@@ -98,7 +106,7 @@ Follow the completion procedure in [plan-mode.md](plan-mode.md) — final valida
 
 - Hit a blocker (missing dependency, test fails, instruction unclear)
 - (Plan mode) Plan has critical gaps preventing starting
-- You don't understand a requirement
+- You don't understand a requirement or instruction is ambiguous
 - Verification fails repeatedly
 
 **IMPORTANT! Always ask for clarification rather than guessing.**
@@ -114,7 +122,9 @@ Follow the completion procedure in [plan-mode.md](plan-mode.md) — final valida
 
 ## Remember
 
-- Understand the problem before writing code
+- Review plan critically first
+- Follow plan steps exactly
 - Don't skip verifications
-- Use skills when applicable (dependency-handling, test, review-code)
+- Use skills when applicable (dependency-handling, test, review-code) (Plan mode: also when the plan says to do so)
+- Between batches: just report and wait
 - Stop when blocked, don't guess

--- a/klaude-plugin/skills/implement/SKILL.md
+++ b/klaude-plugin/skills/implement/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: implement
 description: |
-  TRIGGER when: user asks to work on, implement, or continue tasks from docs/wip (e.g. "work on task 1", "do the next task", "implement first task for X").
-  Executes written implementation plans with review checkpoints. Use when you have a fully-formed implementation plan to execute in a separate session.
+  TRIGGER when: user asks to implement, fix, build, or work on something — whether from a
+  docs/wip plan OR a standalone task (bug fix, GitHub issue, one-off change).
+  Examples: "work on task 1", "fix this bug", "implement feature X from the issue".
+  Provides structured execution with profile detection, dependency handling, review checkpoints.
 ---
 
-# Executing Plans
+# Implementing Work
 
 ## Conventions
 
@@ -13,68 +15,63 @@ Read capy knowledge base conventions at [shared-capy-knowledge-protocol.md](shar
 
 Profile detection is delegated to [shared-profile-detection.md](shared-profile-detection.md). When the sub-task's target files activate a profile that contributes an `implement/` subdirectory (e.g., `${CLAUDE_PLUGIN_ROOT}/profiles/k8s/implement/`), its `index.md` lists per-task gotchas the skill must consult BEFORE writing. See Step 2.
 
+## Modes
+
+Two modes, determined automatically: **plan mode** when the user references a docs/wip feature or task number; **standalone mode** otherwise (bug fix, GitHub issue, one-off change). When ambiguous, ask.
+
+- **Plan mode:** Read [plan-mode.md](plan-mode.md) for entry, iteration, and completion procedures.
+- **Standalone mode:** Read [standalone-mode.md](standalone-mode.md) for entry procedure.
+
+Both modes share the same execution core (Step 2 onward) — profile detection, dependency handling, verification, review.
+
 ## Required Outputs
 
-Per sub-task cycle (Steps 2–3), verify all outputs are delivered:
+After each execution + review cycle, verify all outputs:
 
-- [ ] Implementation matches plan
+- [ ] Implementation addresses the requirement (plan mode: matches plan)
 - [ ] Verification/tests pass
 - [ ] Code review completed (via `review-code` — which owns indexing its own `kk:review-findings`)
 - [ ] New project conventions indexed as `kk:project-conventions` (skip if none established)
-- [ ] `tasks.md` updated to `done`
+- [ ] (Plan mode only) `tasks.md` updated to `done`
 
 **Indexing ownership:** Review skills (`review-code`, `review-spec`) index their own findings. This skill only indexes `kk:project-conventions` for non-obvious patterns discovered during implementation. Do NOT duplicate review indexing here.
-
-## Overview
-
-Load plan, review critically, execute tasks in batches, report for review between batches.
-
-**Core principle:** Batch execution with checkpoints for architect review.
 
 ### Review Mode
 
 By default, review checkpoints use standard mode. The user can request **isolated review mode** for the entire session:
 
 - When invoking the skill: "use isolated review" or "isolated mode"
-- In `tasks.md` metadata: a `review-mode: isolated` field in the header
+- In `tasks.md` metadata (plan mode only): a `review-mode: isolated` field in the header
 
 When set, all review checkpoints automatically use isolated variants (`kk:review-code:isolated`, `kk:review-spec:isolated`) without per-checkpoint prompting. The user can override at any checkpoint ("use standard review for this one").
 
 ## Workflow
 
-**Mandatory order — plan before execution.** The flow below is strictly sequential. Do not read source files to modify, write code, edit files, run tests, or otherwise act on any sub-task until you have loaded the full plan context (design, implementation plan, task list) and, for each sub-task, completed profile detection and loaded all resolved profile content. The only early contact with the codebase is the task's target filenames — enough to drive profile detection, not enough to pattern-match implementation. See [ADR 0004](../../../docs/adr/0004-skill-workflow-ordering.md) for the rationale.
-
-**Phases** (summary — The Process below has the detailed steps):
-
-1. **Load plan context.** Read `tasks.md`, `design.md`, and `implementation.md`. Search capy knowledge base for relevant prior context. Identify the next pending task.
-2. **Per sub-task: detect active profiles.** Run the shared profile-detection procedure against the sub-task's target files.
-3. **Per sub-task: load profile content.** For each active profile contributing an `implement/` subdirectory, load its `index.md` and resolved content (per-task gotchas, coding guidelines).
-4. **Per sub-task: execute.** Only now: read source files, write code, run tests, apply the plan.
-5. **Report and review.** Show results, run code review, update task status.
+**Mandatory order — understand before executing.** The flow below is strictly sequential. Do not read source files to modify, write code, edit files, run tests, or otherwise act on any task until you have loaded full context (plan documents or problem understanding) and completed profile detection and loaded all resolved profile content. The only early contact with the codebase is the task's target filenames — enough to drive profile detection, not enough to pattern-match implementation. See [ADR 0004](../../../docs/adr/0004-skill-workflow-ordering.md) for the rationale.
 
 ## The Process
 
-### Step 1: Load and Review Plan
+### Step 1: Load Context
 
-1. Read the feature's `tasks.md` file to get the task list and current progress
-2. Read the linked `design.md` and `implementation.md` for full context
-3. Identify the next pending task (one whose dependencies are all done)
-4. **Capy search:** Search `kk:arch-decisions`, `kk:project-conventions`, `kk:lang-idioms`, and `kk:review-findings` for context relevant to the identified task
-5. Review critically — identify any questions or concerns about the plan
-6. If concerns: Raise them with your human partner before starting
+Determine mode (see §Modes), then read the appropriate mode file and follow its entry procedure:
 
-### Step 2: Execute Sub-Task
+- **Plan mode:** Read [plan-mode.md](plan-mode.md) — loads tasks.md, design.md, implementation.md, identifies next task.
+- **Standalone mode:** Read [standalone-mode.md](standalone-mode.md) — parses the problem, explores relevant code, forms an approach.
 
-**Mandatory order — instructions before action.** Steps 1–3 load instructions the sub-task needs; step 4 is the first step that touches subject matter. Do not write code, edit files, or otherwise act on the sub-task until steps 1–3 have been performed in order. If a later step reveals that an instruction was missed, return to step 1.
+After completing the mode's entry procedure, continue with Step 2.
 
-1. Update `tasks.md`: set the task's status to `in-progress`.
-2. **Profile-aware per-task gotchas (pre-write).** Run the shared profile-detection procedure against the sub-task's target files (and any diff-so-far). For each active profile that contributes an `implement/` subdirectory, load `${CLAUDE_PLUGIN_ROOT}/profiles/<name>/implement/index.md` and read the always-load + any matching conditional content. Apply those gotchas to the upcoming edits — they exist to prevent mistakes the post-write reviewer would otherwise catch. If no active profile contributes an `implement/` subdirectory, skip this step.
-3. **Dependency-handling (pre-write).** Whenever the sub-task introduces or changes a dependency — new import, version bump, unfamiliar call, **and per the widened trigger also: a Kubernetes API version, a CRD, a Helm chart or chart dependency, or a container image tag/digest** — apply the `dependency-handling` skill BEFORE writing the call. Do not guess signatures, API versions, or configuration; look them up via capy/context7 per that skill's rules. Per-profile lookup cascades live in each profile's `overview.md` (e.g., `${CLAUDE_PLUGIN_ROOT}/profiles/k8s/overview.md` §Looking up Kubernetes dependencies).
-4. Follow the plan exactly.
-5. Check off subtasks (`- [x]`) in `tasks.md` as you complete them.
-6. Run verifications as specified; use `test` skill.
+### Step 2: Execute
 
-### Step 3: Report
+**Mandatory order — instructions before action.** Steps 1–3 load instructions; step 4 is the first step that touches subject matter. Do not write code, edit files, or otherwise act until steps 1–3 have been performed in order. If a later step reveals that an instruction was missed, return to step 1.
+
+1. (Plan mode only) Update `tasks.md`: set the task's status to `in-progress`.
+2. **Profile-aware per-task gotchas (pre-write).** Run the shared profile-detection procedure against the target files (and any diff-so-far). For each active profile that contributes an `implement/` subdirectory, load `${CLAUDE_PLUGIN_ROOT}/profiles/<name>/implement/index.md` and read the always-load + any matching conditional content. Apply those gotchas to the upcoming edits — they exist to prevent mistakes the post-write reviewer would otherwise catch. If no active profile contributes an `implement/` subdirectory, skip this step.
+3. **Dependency-handling (pre-write).** Whenever the task introduces or changes a dependency — new import, version bump, unfamiliar call, **and per the widened trigger also: a Kubernetes API version, a CRD, a Helm chart or chart dependency, or a container image tag/digest** — apply the `dependency-handling` skill BEFORE writing the call. Do not guess signatures, API versions, or configuration; look them up via capy/context7 per that skill's rules. Per-profile lookup cascades live in each profile's `overview.md` (e.g., `${CLAUDE_PLUGIN_ROOT}/profiles/k8s/overview.md` §Looking up Kubernetes dependencies).
+4. Make the changes. (Plan mode: follow the plan exactly.)
+5. (Plan mode only) Check off subtasks (`- [x]`) in `tasks.md` as you complete them.
+6. Run verifications; use `test` skill.
+
+### Step 3: Report and Review
 
 - Show what was implemented
 - Show verification output
@@ -82,58 +79,42 @@ When set, all review checkpoints automatically use isolated variants (`kk:review
 - **Otherwise**: prompt user for code-review (mention isolated mode as an option); if user responds 'yes':
   - **Standard review** (default): Use `review-code` skill, then run `pal` mcp code-review, consolidate findings
   - **Isolated review** (if user requests): Use `kk:review-code:isolated` — same as above
-- Based on user and code-review feedback: apply changes if needed and finalize the sub-task
-- When completed, update `tasks.md`: set the task's status to `done`
+- Based on user and code-review feedback: apply changes if needed and finalize
+- (Plan mode only) Update `tasks.md`: set the task's status to `done`
 
-**After finalizing the sub-task**, verify all items in the **Required Outputs** section above before moving to Step 4:
+**After finalizing**, verify all items in the **Required Outputs** section above. If any item is unchecked, go back and complete it.
 
-- [ ] Implementation matches plan
-- [ ] Verification/tests pass
-- [ ] Code review completed (review skill owns its own `kk:review-findings` indexing)
-- [ ] New project conventions indexed as `kk:project-conventions` (or noted "No new conventions to index")
-- [ ] `tasks.md` updated to `done`
+### Step 4: Continue (plan mode only)
 
-If any item is unchecked, go back and complete it. Do NOT proceed to the next task with incomplete outputs.
+Follow the iteration procedure in [plan-mode.md](plan-mode.md) — move to next task, repeat Steps 1–3.
 
-### Step 4: Continue
+### Step 5: Complete (plan mode only)
 
-- Move to the next pending task in `tasks.md`
-- Repeat until all tasks are completed
-
-### Step 5: Complete Development
-
-After all tasks complete and verified:
-
-- Use `test` skill to verify and validate functionality
-- Use `document` skill to create or update any relevant docs
-- **Reflect:** briefly note where the implementation diverged from the plan, what turned out harder or simpler than expected, and any surprises that future work in this area should know about. Keep it short — a paragraph, not an essay. Index non-obvious learnings as `kk:project-conventions` or `kk:arch-decisions` if they weren't already captured during per-task cycles.
-- Update the feature status in `tasks.md` header to `done`
+Follow the completion procedure in [plan-mode.md](plan-mode.md) — final validation, documentation, reflection.
 
 ## When to Stop and Ask for Help
 
 **STOP executing immediately when:**
 
-- Hit a blocker mid-batch (missing dependency, test fails, instruction unclear)
-- Plan has critical gaps preventing starting
-- You don't understand an instruction
+- Hit a blocker (missing dependency, test fails, instruction unclear)
+- (Plan mode) Plan has critical gaps preventing starting
+- You don't understand a requirement
 - Verification fails repeatedly
 
 **IMPORTANT! Always ask for clarification rather than guessing.**
 
 ## When to Revisit Earlier Steps
 
-**Return to Review (Step 1) when:**
+**Return to Step 1 when:**
 
-- Partner updates the plan based on your feedback
+- Partner updates the plan or clarifies the problem
 - Fundamental approach needs rethinking
 
-**IMPORTANT! Don't force through blockers** - stop and ask.
+**IMPORTANT! Don't force through blockers** — stop and ask.
 
 ## Remember
 
-- Review plan critically first
-- Follow plan steps exactly
+- Understand the problem before writing code
 - Don't skip verifications
-- Use skills when the plan says to do so
-- Between batches: just report and wait
+- Use skills when applicable (dependency-handling, test, review-code)
 - Stop when blocked, don't guess

--- a/klaude-plugin/skills/implement/plan-mode.md
+++ b/klaude-plugin/skills/implement/plan-mode.md
@@ -1,0 +1,32 @@
+# Plan Mode
+
+Applies when the user references a docs/wip feature or task number.
+
+## Entry Procedure
+
+1. Read the feature's `tasks.md` file to get the task list and current progress
+2. Read the linked `design.md` and `implementation.md` for full context
+3. Identify the next pending task (one whose dependencies are all done)
+4. **Capy search:** Search `kk:arch-decisions`, `kk:project-conventions`, `kk:lang-idioms`, and `kk:review-findings` for context relevant to the identified task
+5. Review critically — identify any questions or concerns about the plan
+6. If concerns: Raise them with your human partner before starting
+
+After completing the entry procedure, return to SKILL.md Step 2 (Execute).
+
+## Iteration
+
+After each execution + review cycle (SKILL.md Steps 2–3):
+
+- Verify the completed task's **Required Outputs** are all checked
+- Move to the next pending task in `tasks.md`
+- Return to the Entry Procedure above to load context for the new task
+- Repeat until all tasks are completed
+
+## Completion
+
+After all tasks are complete and verified:
+
+- Use `test` skill to verify and validate functionality
+- Use `document` skill to create or update any relevant docs
+- **Reflect:** briefly note where the implementation diverged from the plan, what turned out harder or simpler than expected, and any surprises that future work in this area should know about. Keep it short — a paragraph, not an essay. Index non-obvious learnings as `kk:project-conventions` or `kk:arch-decisions` if they weren't already captured during per-task cycles.
+- Update the feature status in `tasks.md` header to `done`

--- a/klaude-plugin/skills/implement/standalone-mode.md
+++ b/klaude-plugin/skills/implement/standalone-mode.md
@@ -1,0 +1,15 @@
+# Standalone Mode
+
+Applies for bug fixes, GitHub issues, one-off tasks, and any work without docs/wip infrastructure.
+
+## Entry Procedure
+
+1. Parse the user's request — what is the problem or requirement?
+2. If the user references a GitHub issue, fetch it (`gh issue view`)
+3. **Capy search:** Search `kk:arch-decisions`, `kk:project-conventions`, `kk:lang-idioms`, `kk:review-findings`, and `kk:debug-context` for relevant prior context
+4. Identify questions or ambiguities — ask before assuming
+5. Investigate the relevant code — read files, trace call paths, reproduce the bug if applicable
+6. Identify the set of files that will need changes
+7. State the approach briefly if the fix is non-trivial (more than a few lines across 1–2 files). For trivial fixes, proceed directly.
+
+After completing the entry procedure, return to SKILL.md Step 2 (Execute).


### PR DESCRIPTION
The skill previously required docs/wip plan files (tasks.md, design.md, implementation.md), causing it to be skipped for bug fixes and GitHub issues despite its useful guardrails (profile detection, dependency handling, review checkpoints).

Extract mode-specific logic into sibling files (plan-mode.md, standalone-mode.md) while keeping the shared execution core in SKILL.md.