### PR TITLE
(fix) Rename codex_hooks to hooks for Codex v0.130.0

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -6,7 +6,7 @@ approval_policy = "on-request"
 sandbox_mode = "workspace-write"
 
 [features]
-codex_hooks = true
+hooks = true
 
 [agents]
 max_threads = 6

--- a/test/test-template-sync.sh
+++ b/test/test-template-sync.sh
@@ -586,7 +586,7 @@ model = "gpt-5.5"
 approval_policy = "on-request"
 
 [features]
-codex_hooks = true
+hooks = true
 
 [mcp_servers.capy]
 command = "bash"


### PR DESCRIPTION
Codex v0.130.0 deprecated [features].codex_hooks in favor of [features].hooks. Fixes #107.