### PR TITLE
Enrich pal codereview (Reviewer B) context in isolated code review

### DIFF
--- a/docs/reviews/diff-skill/review-code-13d065f-210d3f4.md
+++ b/docs/reviews/diff-skill/review-code-13d065f-210d3f4.md
@@ -1,0 +1,45 @@
+# diff-skill: review-code (13d065f → 210d3f4)
+
+## Summary
+
+**Verdict: Complexity regressed.** No load-bearing instructions were dropped or weakened — the diff, profile checklists, spec context, and task scope all still reach pal, just via `relevant_files` instead of inlined in `step`. However, the edit introduced two complexity concerns: parallel definitions of the same 5-category file list in two files that must stay synchronized, and a judgment-heavy "surrounding code files" collection step without clear bounds or verification criteria.
+
+## Complexity Regressions
+
+### 1. Parallel file-list definitions across two files
+
+**Where:** `review-isolated.md` Step 1g and `pal-codereview-invocation.md` §Assembling `relevant_files`.
+
+**What:** The same 5-category file list (diff file, changed sources, surrounding code, profile checklists, design docs) is defined in both files with slightly different framing — the shared file documents the protocol interface (what pal expects), the skill file documents the caller implementation (how to collect). Both enumerate the same categories in the same order with overlapping descriptions.
+
+**Why it matters:** Changes to the categorization must be synchronized across both files. If a future edit updates one without the other, the caller and protocol will drift. This is the classic "same list in two places" maintenance hazard. Consider whether the shared file's `relevant_files` section could be authoritative, with the skill file referencing it rather than restating it.
+
+**Status: Acknowledged, won't fix.** The duplication is structural — interface vs implementation. The shared doc defines the protocol contract (what categories pal expects); Step 1g defines the caller implementation (how to collect each category, with specific tool instructions and cross-references to earlier substeps). Deduplicating by making the shared doc authoritative would force the LLM to jump to a second file mid-step to learn the categories, then return for collection instructions, then cross-reference substeps 1a/1b/1c — three locations to assemble a single list. The current inline definition keeps Step 1g self-contained for sequential execution. The drift risk is low: the categories are stable (they map to fundamental code review artifact types), and updating both places on change is trivial.
+
+### 2. Judgment-heavy "surrounding code files" collection
+
+**Where:** `review-isolated.md` Step 1g, category #3.
+
+**What:** The instruction asks the LLM to "identify direct imports, callers, interfaces, and type definitions referenced in the diff" and "Use `grep`/`rg` to locate these. Include files that a reviewer would need to verify cross-file correctness." The bounding guidance is "aim for the immediate dependency ring, not transitive closure."
+
+**Why it matters:** "Immediate dependency ring" is subjective — different executions on the same diff could produce very different file sets depending on how aggressively the LLM follows import chains. There is no cap on file count, no verification step to confirm the set is reasonable, and no fallback if the search produces too many or too few files. For a step that feeds directly into `relevant_files` (which has token budget implications in pal), unbounded output is a practical risk.
+
+**Status: Addressed.** Step 1g category #3 now has a 10-file cap, a prioritized collection order (imports > callers > adjacency), and a fallback (drop adjacency if over cap). The shared protocol mirrors the cap.
+
+## Pre-existing Complexity
+
+### 1. Step 1 substep density
+
+**Where:** `review-isolated.md` Step 1, substeps 1a–1g.
+
+**What:** Step 1 "Prepare Artifacts" now has 7 substeps that produce artifacts with cross-references between them (e.g., 1g references the temp file from 1a, the profile list from 1c, and the spec context from 1b). While the edit added only one substep (1g), the structural complexity of managing 7 artifact-gathering substeps with forward and backward dependencies existed at 6 substeps already.
+
+**Why it matters:** High substep count in a single phase increases the chance of an LLM skipping or conflating steps. Each artifact-passing dependency (1g depends on 1a, 1b, 1c) is implicit rather than enforced. This is a candidate for restructuring — e.g., grouping the "collect for pal" concerns (1a temp file write, 1g file list) into a single focused substep.
+
+## Neutral Changes
+
+- **Step 1a: Diff temp file.** Added `git diff > /tmp/kk-review-diff-$(git rev-parse --short HEAD).patch`. This is a new instruction (not a relocation) that serves the new `relevant_files` delivery mechanism. It's well-specified and bounded.
+- **Step 2 Reviewer B: `step` parameter reworked.** The before-state said to include the git diff in `step`; the after-state says not to and instead passes content via `relevant_files`. The substance (pal gets the diff) is preserved via a different mechanism. The new `step` structure (framing + scope + spec summary + file manifest) is more prescriptive, not less.
+- **`pal-codereview-invocation.md`: `step` content section.** New section with a clear example of the file manifest format. Adds specification but is well-structured.
+- **Checklist and Contents update.** "(1a–1g)" and the 1g entry in Contents correctly reflect the new substep.
+- **Second link to `shared-pal-codereview-invocation.md`.** Added in the Step 2 `step` parameter description. Resolves correctly; provides navigability to the format spec.

--- a/klaude-plugin/skills/_shared/pal-codereview-invocation.md
+++ b/klaude-plugin/skills/_shared/pal-codereview-invocation.md
@@ -9,7 +9,7 @@ Use these parameters:
 | Parameter | Value |
 |---|---|
 | `model` | The most capable model from `pal listmodels` |
-| `step` | The content to review (document text or git diff), prefixed with a framing instruction |
+| `step` | Framing instruction + task scope + spec context summary (see §`step` content below). Keep it lean — file contents belong in `relevant_files`, not here |
 | `step_number` | `1` |
 | `total_steps` | `2` |
 | `next_step_required` | `true` |
@@ -17,8 +17,42 @@ Use these parameters:
 | `thinking_mode` | `"max"` |
 | `review_type` | `"full"` |
 | `findings` | `"Initial submission for review. No findings yet."` |
-| `relevant_files` | Absolute paths of the files being reviewed |
+| `relevant_files` | Absolute paths — see §Assembling `relevant_files` below |
 | `confidence` | `"exploring"` |
+
+#### `step` content
+
+The `step` field carries the review framing — not the diff or file contents. Structure it as:
+
+1. **Framing instruction** — what kind of review this is and what to focus on.
+2. **Task scope block** — in-scope vs out-of-scope tasks (prevents false positives on pending work).
+3. **Spec context summary** — one-paragraph design intent if available ("No spec context available" otherwise).
+4. **File manifest** — a categorized list of the paths in `relevant_files`, explaining each file's role. Paths only, no contents. Example:
+
+   ```
+   Files provided via relevant_files:
+   - Diff: /tmp/kk-review-diff-abc123.patch
+   - Changed: src/service.go, src/handler.go
+   - Surrounding: src/types.go, src/middleware.go
+   - Review checklists: .../profiles/go/review-code/solid-checklist.md
+   - Design: docs/wip/auth-refactor/design.md, implementation.md
+   ```
+
+   This tells pal which files are code under review, which are review criteria to apply, and which provide design intent. Without it, pal may treat checklists as code to review rather than guidance to follow.
+
+Do NOT inline file contents into `step`. These are passed via `relevant_files` — pal reads them with proper token budgeting and deduplication.
+
+#### Assembling `relevant_files`
+
+The caller assembles this list from artifacts gathered during preparation. All paths must be absolute. Categories, in order:
+
+1. **Diff file** — the git diff written to a temp file (e.g., `/tmp/kk-review-diff-<hash>.patch`). The caller writes this file; pal reads it.
+2. **Changed source files** — every file touched by the diff. These give pal the full file context around each change.
+3. **Surrounding code files** — direct imports, callers, interfaces, and type definitions referenced by the changed code. These enable cross-file reasoning (e.g., verifying a called function's signature, checking convention consistency with adjacent files). The caller identifies these by scanning imports and references in the diff.
+4. **Profile checklist files** — resolved `(profile, checklist)` file paths from profile detection (e.g., `<plugin_root>/profiles/go/review-code/solid-checklist.md`). These give pal the same domain-specific review criteria as the sub-agent reviewer.
+5. **Design/implementation docs** — `design.md` and `implementation.md` from the feature's `docs/wip/<feature>/` directory, when available. These enable pal to flag spec deviations, not just code smells.
+
+The caller is responsible for collecting these paths during its preparation steps and passing the assembled list here. pal handles file reading, token budgeting, and cross-turn deduplication internally.
 
 ### Step 2 — continuation call
 

--- a/klaude-plugin/skills/_shared/pal-codereview-invocation.md
+++ b/klaude-plugin/skills/_shared/pal-codereview-invocation.md
@@ -31,7 +31,7 @@ The `step` field carries the review framing — not the diff or file contents. S
 
    ```
    Files provided via relevant_files:
-   - Diff: /tmp/kk-review-diff-abc123.patch
+   - Diff: /tmp/kk-review-code-a1b2c3d4.patch
    - Changed: src/service.go, src/handler.go
    - Surrounding: src/types.go, src/middleware.go
    - Review checklists: .../profiles/go/review-code/solid-checklist.md
@@ -46,7 +46,7 @@ Do NOT inline file contents into `step`. These are passed via `relevant_files` �
 
 The caller assembles this list from artifacts gathered during preparation. All paths must be absolute. Categories, in order:
 
-1. **Diff file** — the git diff written to a temp file (e.g., `/tmp/kk-review-diff-<hash>.patch`). The caller writes this file; pal reads it.
+1. **Diff file** — the git diff written to a temp file via `mktemp` (e.g., `/tmp/kk-review-code-XXXXXXXX.patch`). The caller writes this file; pal reads it. Clean up after the review completes.
 2. **Changed source files** — every file touched by the diff. These give pal the full file context around each change.
 3. **Surrounding code files** — direct imports, callers, interfaces, and type definitions referenced by the changed code. These enable cross-file reasoning (e.g., verifying a called function's signature, checking convention consistency with adjacent files). The caller identifies these by scanning imports and references in the diff.
 4. **Profile checklist files** — resolved `(profile, checklist)` file paths from profile detection (e.g., `<plugin_root>/profiles/go/review-code/solid-checklist.md`). These give pal the same domain-specific review criteria as the sub-agent reviewer.

--- a/klaude-plugin/skills/_shared/pal-codereview-invocation.md
+++ b/klaude-plugin/skills/_shared/pal-codereview-invocation.md
@@ -48,7 +48,7 @@ The caller assembles this list from artifacts gathered during preparation. All p
 
 1. **Diff file** — the git diff written to a temp file via `mktemp` (e.g., `/tmp/kk-review-code-XXXXXXXX.patch`). The caller writes this file; pal reads it. Clean up after the review completes.
 2. **Changed source files** — every file touched by the diff. These give pal the full file context around each change.
-3. **Surrounding code files** — direct imports, callers, interfaces, and type definitions referenced by the changed code. These enable cross-file reasoning (e.g., verifying a called function's signature, checking convention consistency with adjacent files). The caller identifies these by scanning imports and references in the diff.
+3. **Surrounding code files** — direct imports, callers (one level up), and adjacent same-package files that share types with the changed code. Capped at 10 files; prioritize imports and callers over adjacency. These enable cross-file reasoning (e.g., verifying a called function's signature, checking convention consistency).
 4. **Profile checklist files** — resolved `(profile, checklist)` file paths from profile detection (e.g., `<plugin_root>/profiles/go/review-code/solid-checklist.md`). These give pal the same domain-specific review criteria as the sub-agent reviewer.
 5. **Design/implementation docs** — `design.md` and `implementation.md` from the feature's `docs/wip/<feature>/` directory, when available. These enable pal to flag spec deviations, not just code smells.
 

--- a/klaude-plugin/skills/review-code/review-isolated.md
+++ b/klaude-plugin/skills/review-code/review-isolated.md
@@ -4,7 +4,7 @@ Copy this checklist and check off items as you complete them:
 
 ```
 Isolated Code Review Progress:
-- [ ] Step 1: Prepare artifacts
+- [ ] Step 1: Prepare artifacts (1a–1g)
 - [ ] Step 2: Spawn reviewers (parallel)
 - [ ] Step 3: Annotate findings
 - [ ] Step 4: Index findings
@@ -14,7 +14,7 @@ Isolated Code Review Progress:
 
 ## Contents
 
-- **Step 1: Prepare Artifacts** — 1a) Capture diff, 1b) Locate spec context, 1c) Detect active profiles and resolve checklists, 1d) Resolve pal model, 1e) Curate rejected approaches, 1f) Determine task scope
+- **Step 1: Prepare Artifacts** — 1a) Capture diff, 1b) Locate spec context, 1c) Detect active profiles and resolve checklists, 1d) Resolve pal model, 1e) Curate rejected approaches, 1f) Determine task scope, 1g) Collect context files for pal
 - **Step 2: Spawn Reviewers** — Reviewer A (code-reviewer sub-agent), Reviewer B (pal codereview), error handling
 - **Step 3: Annotate Findings** — 3a) Duplicate merging, 3b) Author context, 3c) Author-sourced findings, 3d) pal follow-up
 - **Step 4: Index Findings**
@@ -30,6 +30,14 @@ Gather the artifacts that will be passed to the sub-agents.
 ### 1a) Capture the diff
 
 Run `git diff --stat` and `git diff` to capture the changes under review. If there are no unstaged changes, check for staged changes with `git diff --cached`. If the user specified a commit range, use that instead.
+
+Write the diff to a temp file for pal consumption:
+
+```bash
+git diff > /tmp/kk-review-diff-$(git rev-parse --short HEAD).patch
+```
+
+(Adjust the git diff command to match the actual scope — staged, unstaged, or commit range.)
 
 **Edge cases:**
 
@@ -75,6 +83,18 @@ Build the Task Scope artifact following [shared-review-scope-protocol.md](shared
 - **No feature directory relates to the diff**: emit the "No task scope available" variant from the shared protocol and proceed.
 
 The resulting block is inlined into both reviewer prompts in Step 2.
+
+### 1g) Collect context files for pal
+
+Assemble the file list that will be passed to pal codereview via `relevant_files`. All paths must be absolute.
+
+1. **Diff file** — the temp file written in Step 1a.
+2. **Changed source files** — every file touched by the diff (from `git diff --stat`).
+3. **Surrounding code files** — for each changed file, identify direct imports, callers, interfaces, and type definitions referenced in the diff. Use `grep`/`rg` to locate these. Include files that a reviewer would need to verify cross-file correctness (e.g., checking a function signature, confirming an interface contract, comparing with adjacent module conventions). Keep this bounded — aim for the immediate dependency ring, not transitive closure.
+4. **Profile checklist files** — the absolute paths of every resolved `(profile, checklist)` file from Step 1c. These give pal the same domain-specific review criteria as Reviewer A.
+5. **Design/implementation docs** — if spec context was located in Step 1b, include the full `design.md` and `implementation.md` file paths (not excerpts). These enable pal to flag spec deviations.
+
+Store this list for use in Step 2 (Reviewer B).
 
 ---
 
@@ -128,7 +148,18 @@ Produce your findings in the output format specified in your agent definition.
 
 Follow the invocation protocol in [shared-pal-codereview-invocation.md](shared-pal-codereview-invocation.md).
 
-For the `step` parameter in step 1, prepend the Task Scope block from Step 1f (so pal shares the same scope as the sub-agent) and then include the git diff. For the `model` parameter, use the model resolved in Step 1d.
+**`step` parameter (step 1):** Keep lean — framing + scope + spec summary + file manifest:
+
+1. Framing: "Review the following code changes for correctness, security, architecture, and adherence to design intent. The diff, source files, review checklists, and design docs are provided as files."
+2. Task Scope block from Step 1f.
+3. One-paragraph spec context summary from Step 1b (or "No spec context available — review based on code quality alone.").
+4. File manifest — categorized list of the paths in `relevant_files` so pal knows each file's role (see [shared-pal-codereview-invocation.md](shared-pal-codereview-invocation.md) §`step` content for format).
+
+Do NOT inline the diff or file contents into `step`.
+
+**`relevant_files` parameter:** Use the file list assembled in Step 1g.
+
+**`model` parameter:** Use the model resolved in Step 1d.
 
 ### Parallel execution
 

--- a/klaude-plugin/skills/review-code/review-isolated.md
+++ b/klaude-plugin/skills/review-code/review-isolated.md
@@ -34,10 +34,11 @@ Run `git diff --stat` and `git diff` to capture the changes under review. If the
 Write the diff to a temp file for pal consumption:
 
 ```bash
-git diff > /tmp/kk-review-diff-$(git rev-parse --short HEAD).patch
+diff_file=$(mktemp /tmp/kk-review-code-XXXXXXXX.patch)
+git diff > "$diff_file"
 ```
 
-(Adjust the git diff command to match the actual scope — staged, unstaged, or commit range.)
+Adjust the `git diff` command to match the actual scope (staged, unstaged, or commit range). The temp file is passed to pal via `relevant_files` in Step 2 and should be cleaned up after the review completes (`rm "$diff_file"`).
 
 **Edge cases:**
 

--- a/klaude-plugin/skills/review-code/review-isolated.md
+++ b/klaude-plugin/skills/review-code/review-isolated.md
@@ -91,7 +91,11 @@ Assemble the file list that will be passed to pal codereview via `relevant_files
 
 1. **Diff file** — the temp file written in Step 1a.
 2. **Changed source files** — every file touched by the diff (from `git diff --stat`).
-3. **Surrounding code files** — for each changed file, identify direct imports, callers, interfaces, and type definitions referenced in the diff. Use `grep`/`rg` to locate these. Include files that a reviewer would need to verify cross-file correctness (e.g., checking a function signature, confirming an interface contract, comparing with adjacent module conventions). Keep this bounded — aim for the immediate dependency ring, not transitive closure.
+3. **Surrounding code files** — files a reviewer needs to verify cross-file correctness. Collect in priority order, stop at **10 files**:
+   1. Files directly imported by the changed files (type definitions, interfaces, contracts).
+   2. Direct callers of changed public functions/methods (one level up only).
+   3. Adjacent files in the same package/module that share types or conventions with the changed code.
+   Use `grep`/`rg` on import statements and function names to locate these. If more than 10 candidates emerge, keep only categories 1–2. If fewer than 3, that's fine — small diffs legitimately have few dependencies.
 4. **Profile checklist files** — the absolute paths of every resolved `(profile, checklist)` file from Step 1c. These give pal the same domain-specific review criteria as Reviewer A.
 5. **Design/implementation docs** — if spec context was located in Step 1b, include the full `design.md` and `implementation.md` file paths (not excerpts). These enable pal to flag spec deviations.
 

--- a/klaude-plugin/skills/review-design/review-isolated.md
+++ b/klaude-plugin/skills/review-design/review-isolated.md
@@ -40,15 +40,14 @@ Read the in-scope documents from `/docs/wip/[feature]/`.
 
 Call `pal` `listmodels` to get available models. Select the most capable model (prefer latest generation with thinking/reasoning support) for the `pal codereview` call in Step 2.
 
-### 1c) Prepare document content for pal
+### 1c) Collect context files for pal
 
-Since `pal codereview` cannot read files itself, prepare the document contents as a single text block to pass as input. Include clear headers separating each document.
+Assemble the file list that will be passed to pal codereview via `relevant_files`. All paths must be absolute.
 
-**Important:** `pal codereview` is optimized for source code and diffs. When passing design documents, wrap the content with an explicit framing instruction:
+1. **Document files** — the absolute paths of every in-scope document from Step 1a (`design.md`, `implementation.md`, `tasks.md` as determined by scope resolution). These are the primary review targets.
+2. **Related source files** — if the design docs reference specific source files (e.g., files to be created or modified), include those paths when they exist on disk. These give pal implementation context to validate the design against.
 
-> The following is a design document (markdown), not source code. Review it for technical soundness, completeness, internal consistency, and whether it provides sufficient detail for implementation.
-
-This prevents the model from applying code-specific heuristics to prose.
+Store this list for use in Step 2 (Reviewer B).
 
 ---
 
@@ -88,7 +87,16 @@ Read the documents yourself using the Read tool. Produce your findings in the ou
 
 Follow the invocation protocol in [shared-pal-codereview-invocation.md](shared-pal-codereview-invocation.md).
 
-For the `step` parameter in step 1, use the document contents prepared in Step 1c. For the `model` parameter, use the model resolved in Step 1b. Set `focus_on` to `"technical soundness, completeness, internal consistency, edge cases, failure modes"`.
+**`step` parameter (step 1):** Keep lean — framing + file manifest only:
+
+1. Framing: "The following files are design documents (markdown), not source code. Review them for technical soundness, completeness, internal consistency, and whether they provide sufficient detail for implementation. Focus on: edge cases, failure modes, missing constraints, and ambiguities that would block an implementer."
+2. File manifest — categorized list of paths in `relevant_files` so pal knows each file's role (see [shared-pal-codereview-invocation.md](shared-pal-codereview-invocation.md) §`step` content for format). Categories for design review: "Documents" (the review targets) and "Related source" (existing code for context).
+
+Do NOT inline document contents into `step`.
+
+**`relevant_files` parameter:** Use the file list assembled in Step 1c.
+
+**`model` parameter:** Use the model resolved in Step 1b.
 
 ### Parallel execution
 

--- a/kodex-plugin/skills/_shared/pal-codereview-invocation.md
+++ b/kodex-plugin/skills/_shared/pal-codereview-invocation.md
@@ -9,7 +9,7 @@ Use these parameters:
 | Parameter | Value |
 |---|---|
 | `model` | The most capable model from `pal listmodels` |
-| `step` | The content to review (document text or git diff), prefixed with a framing instruction |
+| `step` | Framing instruction + task scope + spec context summary (see §`step` content below). Keep it lean — file contents belong in `relevant_files`, not here |
 | `step_number` | `1` |
 | `total_steps` | `2` |
 | `next_step_required` | `true` |
@@ -17,8 +17,42 @@ Use these parameters:
 | `thinking_mode` | `"max"` |
 | `review_type` | `"full"` |
 | `findings` | `"Initial submission for review. No findings yet."` |
-| `relevant_files` | Absolute paths of the files being reviewed |
+| `relevant_files` | Absolute paths — see §Assembling `relevant_files` below |
 | `confidence` | `"exploring"` |
+
+#### `step` content
+
+The `step` field carries the review framing — not the diff or file contents. Structure it as:
+
+1. **Framing instruction** — what kind of review this is and what to focus on.
+2. **Task scope block** — in-scope vs out-of-scope tasks (prevents false positives on pending work).
+3. **Spec context summary** — one-paragraph design intent if available ("No spec context available" otherwise).
+4. **File manifest** — a categorized list of the paths in `relevant_files`, explaining each file's role. Paths only, no contents. Example:
+
+   ```
+   Files provided via relevant_files:
+   - Diff: /tmp/kk-review-diff-abc123.patch
+   - Changed: src/service.go, src/handler.go
+   - Surrounding: src/types.go, src/middleware.go
+   - Review checklists: .../profiles/go/review-code/solid-checklist.md
+   - Design: docs/wip/auth-refactor/design.md, implementation.md
+   ```
+
+   This tells pal which files are code under review, which are review criteria to apply, and which provide design intent. Without it, pal may treat checklists as code to review rather than guidance to follow.
+
+Do NOT inline file contents into `step`. These are passed via `relevant_files` — pal reads them with proper token budgeting and deduplication.
+
+#### Assembling `relevant_files`
+
+The caller assembles this list from artifacts gathered during preparation. All paths must be absolute. Categories, in order:
+
+1. **Diff file** — the git diff written to a temp file (e.g., `/tmp/kk-review-diff-<hash>.patch`). The caller writes this file; pal reads it.
+2. **Changed source files** — every file touched by the diff. These give pal the full file context around each change.
+3. **Surrounding code files** — direct imports, callers, interfaces, and type definitions referenced by the changed code. These enable cross-file reasoning (e.g., verifying a called function's signature, checking convention consistency with adjacent files). The caller identifies these by scanning imports and references in the diff.
+4. **Profile checklist files** — resolved `(profile, checklist)` file paths from profile detection (e.g., `<plugin_root>/profiles/go/review-code/solid-checklist.md`). These give pal the same domain-specific review criteria as the sub-agent reviewer.
+5. **Design/implementation docs** — `design.md` and `implementation.md` from the feature's `docs/wip/<feature>/` directory, when available. These enable pal to flag spec deviations, not just code smells.
+
+The caller is responsible for collecting these paths during its preparation steps and passing the assembled list here. pal handles file reading, token budgeting, and cross-turn deduplication internally.
 
 ### Step 2 — continuation call
 

--- a/kodex-plugin/skills/_shared/pal-codereview-invocation.md
+++ b/kodex-plugin/skills/_shared/pal-codereview-invocation.md
@@ -31,7 +31,7 @@ The `step` field carries the review framing — not the diff or file contents. S
 
    ```
    Files provided via relevant_files:
-   - Diff: /tmp/kk-review-diff-abc123.patch
+   - Diff: /tmp/kk-review-code-a1b2c3d4.patch
    - Changed: src/service.go, src/handler.go
    - Surrounding: src/types.go, src/middleware.go
    - Review checklists: .../profiles/go/review-code/solid-checklist.md
@@ -46,7 +46,7 @@ Do NOT inline file contents into `step`. These are passed via `relevant_files` �
 
 The caller assembles this list from artifacts gathered during preparation. All paths must be absolute. Categories, in order:
 
-1. **Diff file** — the git diff written to a temp file (e.g., `/tmp/kk-review-diff-<hash>.patch`). The caller writes this file; pal reads it.
+1. **Diff file** — the git diff written to a temp file via `mktemp` (e.g., `/tmp/kk-review-code-XXXXXXXX.patch`). The caller writes this file; pal reads it. Clean up after the review completes.
 2. **Changed source files** — every file touched by the diff. These give pal the full file context around each change.
 3. **Surrounding code files** — direct imports, callers, interfaces, and type definitions referenced by the changed code. These enable cross-file reasoning (e.g., verifying a called function's signature, checking convention consistency with adjacent files). The caller identifies these by scanning imports and references in the diff.
 4. **Profile checklist files** — resolved `(profile, checklist)` file paths from profile detection (e.g., `<plugin_root>/profiles/go/review-code/solid-checklist.md`). These give pal the same domain-specific review criteria as the sub-agent reviewer.

--- a/kodex-plugin/skills/_shared/pal-codereview-invocation.md
+++ b/kodex-plugin/skills/_shared/pal-codereview-invocation.md
@@ -48,7 +48,7 @@ The caller assembles this list from artifacts gathered during preparation. All p
 
 1. **Diff file** — the git diff written to a temp file via `mktemp` (e.g., `/tmp/kk-review-code-XXXXXXXX.patch`). The caller writes this file; pal reads it. Clean up after the review completes.
 2. **Changed source files** — every file touched by the diff. These give pal the full file context around each change.
-3. **Surrounding code files** — direct imports, callers, interfaces, and type definitions referenced by the changed code. These enable cross-file reasoning (e.g., verifying a called function's signature, checking convention consistency with adjacent files). The caller identifies these by scanning imports and references in the diff.
+3. **Surrounding code files** — direct imports, callers (one level up), and adjacent same-package files that share types with the changed code. Capped at 10 files; prioritize imports and callers over adjacency. These enable cross-file reasoning (e.g., verifying a called function's signature, checking convention consistency).
 4. **Profile checklist files** — resolved `(profile, checklist)` file paths from profile detection (e.g., `<plugin_root>/profiles/go/review-code/solid-checklist.md`). These give pal the same domain-specific review criteria as the sub-agent reviewer.
 5. **Design/implementation docs** — `design.md` and `implementation.md` from the feature's `docs/wip/<feature>/` directory, when available. These enable pal to flag spec deviations, not just code smells.
 

--- a/kodex-plugin/skills/review-code/review-isolated.md
+++ b/kodex-plugin/skills/review-code/review-isolated.md
@@ -4,7 +4,7 @@ Copy this checklist and check off items as you complete them:
 
 ```
 Isolated Code Review Progress:
-- [ ] Step 1: Prepare artifacts
+- [ ] Step 1: Prepare artifacts (1a–1g)
 - [ ] Step 2: Spawn reviewers (parallel)
 - [ ] Step 3: Annotate findings
 - [ ] Step 4: Index findings
@@ -14,7 +14,7 @@ Isolated Code Review Progress:
 
 ## Contents
 
-- **Step 1: Prepare Artifacts** — 1a) Capture diff, 1b) Locate spec context, 1c) Detect active profiles and resolve checklists, 1d) Resolve pal model, 1e) Curate rejected approaches, 1f) Determine task scope
+- **Step 1: Prepare Artifacts** — 1a) Capture diff, 1b) Locate spec context, 1c) Detect active profiles and resolve checklists, 1d) Resolve pal model, 1e) Curate rejected approaches, 1f) Determine task scope, 1g) Collect context files for pal
 - **Step 2: Spawn Reviewers** — Reviewer A (code-reviewer sub-agent), Reviewer B (pal codereview), error handling
 - **Step 3: Annotate Findings** — 3a) Duplicate merging, 3b) Author context, 3c) Author-sourced findings, 3d) pal follow-up
 - **Step 4: Index Findings**
@@ -30,6 +30,14 @@ Gather the artifacts that will be passed to the sub-agents.
 ### 1a) Capture the diff
 
 Run `git diff --stat` and `git diff` to capture the changes under review. If there are no unstaged changes, check for staged changes with `git diff --cached`. If the user specified a commit range, use that instead.
+
+Write the diff to a temp file for pal consumption:
+
+```bash
+git diff > /tmp/kk-review-diff-$(git rev-parse --short HEAD).patch
+```
+
+(Adjust the git diff command to match the actual scope — staged, unstaged, or commit range.)
 
 **Edge cases:**
 
@@ -75,6 +83,18 @@ Build the Task Scope artifact following [shared-review-scope-protocol.md](shared
 - **No feature directory relates to the diff**: emit the "No task scope available" variant from the shared protocol and proceed.
 
 The resulting block is inlined into both reviewer prompts in Step 2.
+
+### 1g) Collect context files for pal
+
+Assemble the file list that will be passed to pal codereview via `relevant_files`. All paths must be absolute.
+
+1. **Diff file** — the temp file written in Step 1a.
+2. **Changed source files** — every file touched by the diff (from `git diff --stat`).
+3. **Surrounding code files** — for each changed file, identify direct imports, callers, interfaces, and type definitions referenced in the diff. Use `grep`/`rg` to locate these. Include files that a reviewer would need to verify cross-file correctness (e.g., checking a function signature, confirming an interface contract, comparing with adjacent module conventions). Keep this bounded — aim for the immediate dependency ring, not transitive closure.
+4. **Profile checklist files** — the absolute paths of every resolved `(profile, checklist)` file from Step 1c. These give pal the same domain-specific review criteria as Reviewer A.
+5. **Design/implementation docs** — if spec context was located in Step 1b, include the full `design.md` and `implementation.md` file paths (not excerpts). These enable pal to flag spec deviations.
+
+Store this list for use in Step 2 (Reviewer B).
 
 ---
 
@@ -128,7 +148,18 @@ Produce your findings in the output format specified in your agent definition.
 
 Follow the invocation protocol in [shared-pal-codereview-invocation.md](shared-pal-codereview-invocation.md).
 
-For the `step` parameter in step 1, prepend the Task Scope block from Step 1f (so pal shares the same scope as the sub-agent) and then include the git diff. For the `model` parameter, use the model resolved in Step 1d.
+**`step` parameter (step 1):** Keep lean — framing + scope + spec summary + file manifest:
+
+1. Framing: "Review the following code changes for correctness, security, architecture, and adherence to design intent. The diff, source files, review checklists, and design docs are provided as files."
+2. Task Scope block from Step 1f.
+3. One-paragraph spec context summary from Step 1b (or "No spec context available — review based on code quality alone.").
+4. File manifest — categorized list of the paths in `relevant_files` so pal knows each file's role (see [shared-pal-codereview-invocation.md](shared-pal-codereview-invocation.md) §`step` content for format).
+
+Do NOT inline the diff or file contents into `step`.
+
+**`relevant_files` parameter:** Use the file list assembled in Step 1g.
+
+**`model` parameter:** Use the model resolved in Step 1d.
 
 ### Parallel execution
 

--- a/kodex-plugin/skills/review-code/review-isolated.md
+++ b/kodex-plugin/skills/review-code/review-isolated.md
@@ -34,10 +34,11 @@ Run `git diff --stat` and `git diff` to capture the changes under review. If the
 Write the diff to a temp file for pal consumption:
 
 ```bash
-git diff > /tmp/kk-review-diff-$(git rev-parse --short HEAD).patch
+diff_file=$(mktemp /tmp/kk-review-code-XXXXXXXX.patch)
+git diff > "$diff_file"
 ```
 
-(Adjust the git diff command to match the actual scope — staged, unstaged, or commit range.)
+Adjust the `git diff` command to match the actual scope (staged, unstaged, or commit range). The temp file is passed to pal via `relevant_files` in Step 2 and should be cleaned up after the review completes (`rm "$diff_file"`).
 
 **Edge cases:**
 

--- a/kodex-plugin/skills/review-code/review-isolated.md
+++ b/kodex-plugin/skills/review-code/review-isolated.md
@@ -91,7 +91,11 @@ Assemble the file list that will be passed to pal codereview via `relevant_files
 
 1. **Diff file** — the temp file written in Step 1a.
 2. **Changed source files** — every file touched by the diff (from `git diff --stat`).
-3. **Surrounding code files** — for each changed file, identify direct imports, callers, interfaces, and type definitions referenced in the diff. Use `grep`/`rg` to locate these. Include files that a reviewer would need to verify cross-file correctness (e.g., checking a function signature, confirming an interface contract, comparing with adjacent module conventions). Keep this bounded — aim for the immediate dependency ring, not transitive closure.
+3. **Surrounding code files** — files a reviewer needs to verify cross-file correctness. Collect in priority order, stop at **10 files**:
+   1. Files directly imported by the changed files (type definitions, interfaces, contracts).
+   2. Direct callers of changed public functions/methods (one level up only).
+   3. Adjacent files in the same package/module that share types or conventions with the changed code.
+   Use `grep`/`rg` on import statements and function names to locate these. If more than 10 candidates emerge, keep only categories 1–2. If fewer than 3, that's fine — small diffs legitimately have few dependencies.
 4. **Profile checklist files** — the absolute paths of every resolved `(profile, checklist)` file from Step 1c. These give pal the same domain-specific review criteria as Reviewer A.
 5. **Design/implementation docs** — if spec context was located in Step 1b, include the full `design.md` and `implementation.md` file paths (not excerpts). These enable pal to flag spec deviations.
 

--- a/kodex-plugin/skills/review-code/shared-pal-codereview-invocation.md
+++ b/kodex-plugin/skills/review-code/shared-pal-codereview-invocation.md
@@ -9,7 +9,7 @@ Use these parameters:
 | Parameter | Value |
 |---|---|
 | `model` | The most capable model from `pal listmodels` |
-| `step` | The content to review (document text or git diff), prefixed with a framing instruction |
+| `step` | Framing instruction + task scope + spec context summary (see §`step` content below). Keep it lean — file contents belong in `relevant_files`, not here |
 | `step_number` | `1` |
 | `total_steps` | `2` |
 | `next_step_required` | `true` |
@@ -17,8 +17,42 @@ Use these parameters:
 | `thinking_mode` | `"max"` |
 | `review_type` | `"full"` |
 | `findings` | `"Initial submission for review. No findings yet."` |
-| `relevant_files` | Absolute paths of the files being reviewed |
+| `relevant_files` | Absolute paths — see §Assembling `relevant_files` below |
 | `confidence` | `"exploring"` |
+
+#### `step` content
+
+The `step` field carries the review framing — not the diff or file contents. Structure it as:
+
+1. **Framing instruction** — what kind of review this is and what to focus on.
+2. **Task scope block** — in-scope vs out-of-scope tasks (prevents false positives on pending work).
+3. **Spec context summary** — one-paragraph design intent if available ("No spec context available" otherwise).
+4. **File manifest** — a categorized list of the paths in `relevant_files`, explaining each file's role. Paths only, no contents. Example:
+
+   ```
+   Files provided via relevant_files:
+   - Diff: /tmp/kk-review-diff-abc123.patch
+   - Changed: src/service.go, src/handler.go
+   - Surrounding: src/types.go, src/middleware.go
+   - Review checklists: .../profiles/go/review-code/solid-checklist.md
+   - Design: docs/wip/auth-refactor/design.md, implementation.md
+   ```
+
+   This tells pal which files are code under review, which are review criteria to apply, and which provide design intent. Without it, pal may treat checklists as code to review rather than guidance to follow.
+
+Do NOT inline file contents into `step`. These are passed via `relevant_files` — pal reads them with proper token budgeting and deduplication.
+
+#### Assembling `relevant_files`
+
+The caller assembles this list from artifacts gathered during preparation. All paths must be absolute. Categories, in order:
+
+1. **Diff file** — the git diff written to a temp file (e.g., `/tmp/kk-review-diff-<hash>.patch`). The caller writes this file; pal reads it.
+2. **Changed source files** — every file touched by the diff. These give pal the full file context around each change.
+3. **Surrounding code files** — direct imports, callers, interfaces, and type definitions referenced by the changed code. These enable cross-file reasoning (e.g., verifying a called function's signature, checking convention consistency with adjacent files). The caller identifies these by scanning imports and references in the diff.
+4. **Profile checklist files** — resolved `(profile, checklist)` file paths from profile detection (e.g., `<plugin_root>/profiles/go/review-code/solid-checklist.md`). These give pal the same domain-specific review criteria as the sub-agent reviewer.
+5. **Design/implementation docs** — `design.md` and `implementation.md` from the feature's `docs/wip/<feature>/` directory, when available. These enable pal to flag spec deviations, not just code smells.
+
+The caller is responsible for collecting these paths during its preparation steps and passing the assembled list here. pal handles file reading, token budgeting, and cross-turn deduplication internally.
 
 ### Step 2 — continuation call
 

--- a/kodex-plugin/skills/review-code/shared-pal-codereview-invocation.md
+++ b/kodex-plugin/skills/review-code/shared-pal-codereview-invocation.md
@@ -31,7 +31,7 @@ The `step` field carries the review framing — not the diff or file contents. S
 
    ```
    Files provided via relevant_files:
-   - Diff: /tmp/kk-review-diff-abc123.patch
+   - Diff: /tmp/kk-review-code-a1b2c3d4.patch
    - Changed: src/service.go, src/handler.go
    - Surrounding: src/types.go, src/middleware.go
    - Review checklists: .../profiles/go/review-code/solid-checklist.md
@@ -46,7 +46,7 @@ Do NOT inline file contents into `step`. These are passed via `relevant_files` �
 
 The caller assembles this list from artifacts gathered during preparation. All paths must be absolute. Categories, in order:
 
-1. **Diff file** — the git diff written to a temp file (e.g., `/tmp/kk-review-diff-<hash>.patch`). The caller writes this file; pal reads it.
+1. **Diff file** — the git diff written to a temp file via `mktemp` (e.g., `/tmp/kk-review-code-XXXXXXXX.patch`). The caller writes this file; pal reads it. Clean up after the review completes.
 2. **Changed source files** — every file touched by the diff. These give pal the full file context around each change.
 3. **Surrounding code files** — direct imports, callers, interfaces, and type definitions referenced by the changed code. These enable cross-file reasoning (e.g., verifying a called function's signature, checking convention consistency with adjacent files). The caller identifies these by scanning imports and references in the diff.
 4. **Profile checklist files** — resolved `(profile, checklist)` file paths from profile detection (e.g., `<plugin_root>/profiles/go/review-code/solid-checklist.md`). These give pal the same domain-specific review criteria as the sub-agent reviewer.

--- a/kodex-plugin/skills/review-code/shared-pal-codereview-invocation.md
+++ b/kodex-plugin/skills/review-code/shared-pal-codereview-invocation.md
@@ -48,7 +48,7 @@ The caller assembles this list from artifacts gathered during preparation. All p
 
 1. **Diff file** — the git diff written to a temp file via `mktemp` (e.g., `/tmp/kk-review-code-XXXXXXXX.patch`). The caller writes this file; pal reads it. Clean up after the review completes.
 2. **Changed source files** — every file touched by the diff. These give pal the full file context around each change.
-3. **Surrounding code files** — direct imports, callers, interfaces, and type definitions referenced by the changed code. These enable cross-file reasoning (e.g., verifying a called function's signature, checking convention consistency with adjacent files). The caller identifies these by scanning imports and references in the diff.
+3. **Surrounding code files** — direct imports, callers (one level up), and adjacent same-package files that share types with the changed code. Capped at 10 files; prioritize imports and callers over adjacency. These enable cross-file reasoning (e.g., verifying a called function's signature, checking convention consistency).
 4. **Profile checklist files** — resolved `(profile, checklist)` file paths from profile detection (e.g., `<plugin_root>/profiles/go/review-code/solid-checklist.md`). These give pal the same domain-specific review criteria as the sub-agent reviewer.
 5. **Design/implementation docs** — `design.md` and `implementation.md` from the feature's `docs/wip/<feature>/` directory, when available. These enable pal to flag spec deviations, not just code smells.
 

--- a/kodex-plugin/skills/review-design/review-isolated.md
+++ b/kodex-plugin/skills/review-design/review-isolated.md
@@ -40,15 +40,14 @@ Read the in-scope documents from `/docs/wip/[feature]/`.
 
 Call `pal` `listmodels` to get available models. Select the most capable model (prefer latest generation with thinking/reasoning support) for the `pal codereview` call in Step 2.
 
-### 1c) Prepare document content for pal
+### 1c) Collect context files for pal
 
-Since `pal codereview` cannot read files itself, prepare the document contents as a single text block to pass as input. Include clear headers separating each document.
+Assemble the file list that will be passed to pal codereview via `relevant_files`. All paths must be absolute.
 
-**Important:** `pal codereview` is optimized for source code and diffs. When passing design documents, wrap the content with an explicit framing instruction:
+1. **Document files** — the absolute paths of every in-scope document from Step 1a (`design.md`, `implementation.md`, `tasks.md` as determined by scope resolution). These are the primary review targets.
+2. **Related source files** — if the design docs reference specific source files (e.g., files to be created or modified), include those paths when they exist on disk. These give pal implementation context to validate the design against.
 
-> The following is a design document (markdown), not source code. Review it for technical soundness, completeness, internal consistency, and whether it provides sufficient detail for implementation.
-
-This prevents the model from applying code-specific heuristics to prose.
+Store this list for use in Step 2 (Reviewer B).
 
 ---
 
@@ -88,7 +87,16 @@ Read the documents yourself using the Read tool. Produce your findings in the ou
 
 Follow the invocation protocol in [shared-pal-codereview-invocation.md](shared-pal-codereview-invocation.md).
 
-For the `step` parameter in step 1, use the document contents prepared in Step 1c. For the `model` parameter, use the model resolved in Step 1b. Set `focus_on` to `"technical soundness, completeness, internal consistency, edge cases, failure modes"`.
+**`step` parameter (step 1):** Keep lean — framing + file manifest only:
+
+1. Framing: "The following files are design documents (markdown), not source code. Review them for technical soundness, completeness, internal consistency, and whether they provide sufficient detail for implementation. Focus on: edge cases, failure modes, missing constraints, and ambiguities that would block an implementer."
+2. File manifest — categorized list of paths in `relevant_files` so pal knows each file's role (see [shared-pal-codereview-invocation.md](shared-pal-codereview-invocation.md) §`step` content for format). Categories for design review: "Documents" (the review targets) and "Related source" (existing code for context).
+
+Do NOT inline document contents into `step`.
+
+**`relevant_files` parameter:** Use the file list assembled in Step 1c.
+
+**`model` parameter:** Use the model resolved in Step 1b.
 
 ### Parallel execution
 

--- a/kodex-plugin/skills/review-design/shared-pal-codereview-invocation.md
+++ b/kodex-plugin/skills/review-design/shared-pal-codereview-invocation.md
@@ -9,7 +9,7 @@ Use these parameters:
 | Parameter | Value |
 |---|---|
 | `model` | The most capable model from `pal listmodels` |
-| `step` | The content to review (document text or git diff), prefixed with a framing instruction |
+| `step` | Framing instruction + task scope + spec context summary (see §`step` content below). Keep it lean — file contents belong in `relevant_files`, not here |
 | `step_number` | `1` |
 | `total_steps` | `2` |
 | `next_step_required` | `true` |
@@ -17,8 +17,42 @@ Use these parameters:
 | `thinking_mode` | `"max"` |
 | `review_type` | `"full"` |
 | `findings` | `"Initial submission for review. No findings yet."` |
-| `relevant_files` | Absolute paths of the files being reviewed |
+| `relevant_files` | Absolute paths — see §Assembling `relevant_files` below |
 | `confidence` | `"exploring"` |
+
+#### `step` content
+
+The `step` field carries the review framing — not the diff or file contents. Structure it as:
+
+1. **Framing instruction** — what kind of review this is and what to focus on.
+2. **Task scope block** — in-scope vs out-of-scope tasks (prevents false positives on pending work).
+3. **Spec context summary** — one-paragraph design intent if available ("No spec context available" otherwise).
+4. **File manifest** — a categorized list of the paths in `relevant_files`, explaining each file's role. Paths only, no contents. Example:
+
+   ```
+   Files provided via relevant_files:
+   - Diff: /tmp/kk-review-diff-abc123.patch
+   - Changed: src/service.go, src/handler.go
+   - Surrounding: src/types.go, src/middleware.go
+   - Review checklists: .../profiles/go/review-code/solid-checklist.md
+   - Design: docs/wip/auth-refactor/design.md, implementation.md
+   ```
+
+   This tells pal which files are code under review, which are review criteria to apply, and which provide design intent. Without it, pal may treat checklists as code to review rather than guidance to follow.
+
+Do NOT inline file contents into `step`. These are passed via `relevant_files` — pal reads them with proper token budgeting and deduplication.
+
+#### Assembling `relevant_files`
+
+The caller assembles this list from artifacts gathered during preparation. All paths must be absolute. Categories, in order:
+
+1. **Diff file** — the git diff written to a temp file (e.g., `/tmp/kk-review-diff-<hash>.patch`). The caller writes this file; pal reads it.
+2. **Changed source files** — every file touched by the diff. These give pal the full file context around each change.
+3. **Surrounding code files** — direct imports, callers, interfaces, and type definitions referenced by the changed code. These enable cross-file reasoning (e.g., verifying a called function's signature, checking convention consistency with adjacent files). The caller identifies these by scanning imports and references in the diff.
+4. **Profile checklist files** — resolved `(profile, checklist)` file paths from profile detection (e.g., `<plugin_root>/profiles/go/review-code/solid-checklist.md`). These give pal the same domain-specific review criteria as the sub-agent reviewer.
+5. **Design/implementation docs** — `design.md` and `implementation.md` from the feature's `docs/wip/<feature>/` directory, when available. These enable pal to flag spec deviations, not just code smells.
+
+The caller is responsible for collecting these paths during its preparation steps and passing the assembled list here. pal handles file reading, token budgeting, and cross-turn deduplication internally.
 
 ### Step 2 — continuation call
 

--- a/kodex-plugin/skills/review-design/shared-pal-codereview-invocation.md
+++ b/kodex-plugin/skills/review-design/shared-pal-codereview-invocation.md
@@ -31,7 +31,7 @@ The `step` field carries the review framing — not the diff or file contents. S
 
    ```
    Files provided via relevant_files:
-   - Diff: /tmp/kk-review-diff-abc123.patch
+   - Diff: /tmp/kk-review-code-a1b2c3d4.patch
    - Changed: src/service.go, src/handler.go
    - Surrounding: src/types.go, src/middleware.go
    - Review checklists: .../profiles/go/review-code/solid-checklist.md
@@ -46,7 +46,7 @@ Do NOT inline file contents into `step`. These are passed via `relevant_files` �
 
 The caller assembles this list from artifacts gathered during preparation. All paths must be absolute. Categories, in order:
 
-1. **Diff file** — the git diff written to a temp file (e.g., `/tmp/kk-review-diff-<hash>.patch`). The caller writes this file; pal reads it.
+1. **Diff file** — the git diff written to a temp file via `mktemp` (e.g., `/tmp/kk-review-code-XXXXXXXX.patch`). The caller writes this file; pal reads it. Clean up after the review completes.
 2. **Changed source files** — every file touched by the diff. These give pal the full file context around each change.
 3. **Surrounding code files** — direct imports, callers, interfaces, and type definitions referenced by the changed code. These enable cross-file reasoning (e.g., verifying a called function's signature, checking convention consistency with adjacent files). The caller identifies these by scanning imports and references in the diff.
 4. **Profile checklist files** — resolved `(profile, checklist)` file paths from profile detection (e.g., `<plugin_root>/profiles/go/review-code/solid-checklist.md`). These give pal the same domain-specific review criteria as the sub-agent reviewer.

--- a/kodex-plugin/skills/review-design/shared-pal-codereview-invocation.md
+++ b/kodex-plugin/skills/review-design/shared-pal-codereview-invocation.md
@@ -48,7 +48,7 @@ The caller assembles this list from artifacts gathered during preparation. All p
 
 1. **Diff file** — the git diff written to a temp file via `mktemp` (e.g., `/tmp/kk-review-code-XXXXXXXX.patch`). The caller writes this file; pal reads it. Clean up after the review completes.
 2. **Changed source files** — every file touched by the diff. These give pal the full file context around each change.
-3. **Surrounding code files** — direct imports, callers, interfaces, and type definitions referenced by the changed code. These enable cross-file reasoning (e.g., verifying a called function's signature, checking convention consistency with adjacent files). The caller identifies these by scanning imports and references in the diff.
+3. **Surrounding code files** — direct imports, callers (one level up), and adjacent same-package files that share types with the changed code. Capped at 10 files; prioritize imports and callers over adjacency. These enable cross-file reasoning (e.g., verifying a called function's signature, checking convention consistency).
 4. **Profile checklist files** — resolved `(profile, checklist)` file paths from profile detection (e.g., `<plugin_root>/profiles/go/review-code/solid-checklist.md`). These give pal the same domain-specific review criteria as the sub-agent reviewer.
 5. **Design/implementation docs** — `design.md` and `implementation.md` from the feature's `docs/wip/<feature>/` directory, when available. These enable pal to flag spec deviations, not just code smells.
 


### PR DESCRIPTION
- Enrich pal codereview (Reviewer B) context in isolated code review
  Reviewer B (pal codereview) was receiving only the diff inlined in the
  step field plus the task scope block — no profile checklists, no
  surrounding code files, no design docs. This made it much shallower
  than Reviewer A (code-reviewer sub-agent) which has Read/Grep/Glob
  access to the full codebase.
  Instead of inlining content, leverage pal's native relevant_files
  parameter: write the diff to a temp file, collect changed files,
  surrounding code (imports/callers/interfaces), resolved profile
  checklist paths, and design/implementation docs — pass them all as
  absolute file paths. Pal handles file reading, token budgeting, and
  cross-turn deduplication internally.
  The step field now carries only the framing instruction, task scope,
  spec context summary, and a categorized file manifest so pal knows
  each file's role (code under review vs review criteria vs design
  intent).
- Fix review findings: mktemp for diff file, align review-design with shared protocol
  Two issues from code review:
  1. The diff temp file used a predictable path based on git short hash.
     Replaced with mktemp for unpredictable filenames and OS-default
     restrictive permissions. Added cleanup guidance.
  2. review-design/review-isolated.md contradicted the shared pal
     codereview protocol — it inlined document contents into the step
     field and claimed pal cannot read files. Updated to pass documents
     via relevant_files with a file manifest in step, matching how
     review-code now works.
- Cap surrounding code files at 10 with prioritized collection order
  Addresses diff-skill regression #2: the surrounding code files step
  in Step 1g was unbounded and judgment-heavy. Now has a concrete 10-file
  cap, prioritized collection (imports > callers > adjacency), and a
  fallback that drops adjacency when over cap.
  Also annotates both diff-skill regressions in the review report:
  - #1 (parallel file-list definitions): acknowledged, won't fix —
    duplication is structural (interface vs implementation) and
    deduplicating would harm LLM execution by forcing cross-file jumps
  - #2 (surrounding code files): addressed with this commit