### PR TITLE
Explicitly set models for all plugin subagents

### DIFF
--- a/.codex/agents/code-reviewer.toml
+++ b/.codex/agents/code-reviewer.toml
@@ -1,7 +1,7 @@
 name = "code-reviewer"
 description = "Independent code reviewer with no authorship attachment. Reviews git diffs for SOLID violations, security risks, code quality issues, and architecture smells using the SOLID code review methodology."
 sandbox_mode = "read-only"
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "xhigh"
 developer_instructions = """
 ## Plugin root

--- a/.codex/agents/design-reviewer.toml
+++ b/.codex/agents/design-reviewer.toml
@@ -1,7 +1,7 @@
 name = "design-reviewer"
 description = "Independent design document reviewer with no authorship attachment. Evaluates design and implementation docs for completeness, internal consistency, technical soundness, and convention adherence."
 sandbox_mode = "read-only"
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "xhigh"
 developer_instructions = """
 ## Plugin root

--- a/.codex/agents/eval-grader.toml
+++ b/.codex/agents/eval-grader.toml
@@ -1,7 +1,7 @@
 name = "eval-grader"
 description = "Independent skill-eval grader with no review authorship and no fixture access. Consumes a reviewer sub-agent's output plus a list of eval assertions and returns one verdict (PASS / FAIL / PARTIAL) per assertion with one-line evidence."
 sandbox_mode = "read-only"
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "xhigh"
 developer_instructions = """
 ## Plugin root

--- a/.codex/agents/profile-resolver.toml
+++ b/.codex/agents/profile-resolver.toml
@@ -1,7 +1,7 @@
 name = "profile-resolver"
 description = "Resolves active profiles and their checklist-load decisions for a given diff, using the shared profile-detection procedure. Emits a structured resolution report: active profiles with per-file `triggered_by` signal, plus loaded vs. not-loaded checklists with Load-if reasoning. Useful wherever profile detection must be isolated from downstream work — the /kk:review-code eval harness uses it to grade detection independently of review output, and production skill invocations may delegate detection here to keep the main session's context free of the procedure files."
 sandbox_mode = "read-only"
-model = "gpt-5.4"
+model = "gpt-5.4-mini"
 model_reasoning_effort = "xhigh"
 developer_instructions = """
 ## Plugin root

--- a/.codex/agents/spec-reviewer.toml
+++ b/.codex/agents/spec-reviewer.toml
@@ -1,7 +1,7 @@
 name = "spec-reviewer"
 description = "Independent spec conformance reviewer with no authorship attachment. Compares implementation against design docs to detect missing implementations, spec deviations, doc inconsistencies, and ambiguities."
 sandbox_mode = "read-only"
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "xhigh"
 developer_instructions = """
 ## Plugin root

--- a/klaude-plugin/agents/code-reviewer.md
+++ b/klaude-plugin/agents/code-reviewer.md
@@ -2,6 +2,7 @@
 name: code-reviewer
 description: |
   Independent code reviewer with no authorship attachment. Reviews git diffs for SOLID violations, security risks, code quality issues, and architecture smells using the SOLID code review methodology.
+model: claude-opus-4-8
 tools:
   - Read
   - Grep

--- a/klaude-plugin/agents/design-reviewer.md
+++ b/klaude-plugin/agents/design-reviewer.md
@@ -2,6 +2,7 @@
 name: design-reviewer
 description: |
   Independent design document reviewer with no authorship attachment. Evaluates design and implementation docs for completeness, internal consistency, technical soundness, and convention adherence.
+model: claude-opus-4-8
 tools:
   - Read
   - Grep

--- a/klaude-plugin/agents/eval-grader.md
+++ b/klaude-plugin/agents/eval-grader.md
@@ -2,6 +2,7 @@
 name: eval-grader
 description: |
   Independent skill-eval grader with no review authorship and no fixture access. Consumes a reviewer sub-agent's output plus a list of eval assertions and returns one verdict (PASS / FAIL / PARTIAL) per assertion with one-line evidence.
+model: claude-opus-4-8
 tools:
   - Read
 ---

--- a/klaude-plugin/agents/profile-resolver.md
+++ b/klaude-plugin/agents/profile-resolver.md
@@ -2,6 +2,7 @@
 name: profile-resolver
 description: |
   Resolves active profiles and their checklist-load decisions for a given diff, using the shared profile-detection procedure. Emits a structured resolution report: active profiles with per-file `triggered_by` signal, plus loaded vs. not-loaded checklists with Load-if reasoning. Useful wherever profile detection must be isolated from downstream work — the /kk:review-code eval harness uses it to grade detection independently of review output, and production skill invocations may delegate detection here to keep the main session's context free of the procedure files.
+model: sonnet
 tools:
   - Read
   - Grep

--- a/klaude-plugin/agents/spec-reviewer.md
+++ b/klaude-plugin/agents/spec-reviewer.md
@@ -2,6 +2,7 @@
 name: spec-reviewer
 description: |
   Independent spec conformance reviewer with no authorship attachment. Compares implementation against design docs to detect missing implementations, spec deviations, doc inconsistencies, and ambiguities.
+model: claude-opus-4-8
 tools:
   - Read
   - Grep


### PR DESCRIPTION
Use most capable model available to-date for review tasks.
Use faster model for profile-resolver subagent.

Main reason is defaulting to more capable models for reviews even
when implementation is done by a lesser model.
I.e. defaulting to opus-4-6 for implementation tasks is usually
acceptable because the whole feature spec is documented and
detailed. However, we still want a more capable model to do
independent reviews during implementation.